### PR TITLE
Add mosh support

### DIFF
--- a/AWS/network.tf
+++ b/AWS/network.tf
@@ -1,23 +1,36 @@
+resource "aws_security_group_rule" "ssh" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+  security_group_id = aws_security_group.haskell-dev-vm.id
+}
+
+resource "aws_security_group_rule" "mosh" {
+  type              = "ingress"
+  from_port         = 60000
+  to_port           = 61000
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+  security_group_id = aws_security_group.haskell-dev-vm.id
+}
+
+resource "aws_security_group_rule" "out" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+  security_group_id = aws_security_group.haskell-dev-vm.id
+}
+
 resource "aws_security_group" "haskell-dev-vm" {
   name = "haskell-dev-vm"
   description = "Allow ssh to haskell-dev-vm"
-
-  ingress {
-    from_port = 22
-    to_port   = 22
-    protocol  = "tcp"
-    cidr_blocks = [
-      "0.0.0.0/0"
-    ]
-  }
-
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
 }
 
 resource "aws_eip" "haskell-dev-vm" {

--- a/AWS/provider.tf
+++ b/AWS/provider.tf
@@ -1,2 +1,7 @@
 provider "aws" {
+  default_tags {
+    tags = {
+      environment = "dev-vm"
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ You should now be able to log to the machine with the following command (ensure 
 ssh ubuntu@93.184.216.34
 ```
 
+As an alternative, you may also want to connect using mosh:
+```
+mosh ubuntu@93.184.216.34
+```
+
 # Using the VM
 
 Then one should be able to log into the VM, start tmux and emacs, and then hack some stuff.

--- a/packer/build-env.sh
+++ b/packer/build-env.sh
@@ -9,6 +9,9 @@ export DEBIAN_FRONTEND=noninteractive
 sudo -E apt-get update
 sudo apt install -y apt-transport-https apt-utils ca-certificates curl software-properties-common
 
+# install mosh for smoother terminal interactions
+sudo apt install -y mosh
+
 # install neovim
 sudo add-apt-repository ppa:neovim-ppa/stable
 


### PR DESCRIPTION
For a smoother terminal experience, one may want to connect with mosh.

Note: does not support GCP firewalling yet